### PR TITLE
KP-677 [GCP Load Balancer] Method Create HTTPS External LB - SSL Certificate Autocomplete not working - Function not found!

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
   "execProgram": "node",
   "main": "app.js",
   "imgUrl": "logo.png",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "category": ["CLOUD"],
   "keywords": [
     "GCP",

--- a/config.json
+++ b/config.json
@@ -254,7 +254,7 @@
           "required": true,
           "type": "autocomplete",
           "autocompleteType": "function",
-          "functionName": "listSSLCertificatesAuto",
+          "functionName": "listSslCertificatesAuto",
           "description": "Name of the SSL certificate",
           "placeholder": "select using autocomplete",
           "learnUrl": "https://cloud.google.com/compute/docs/reference/rest/v1/sslCertificates/insert"


### PR DESCRIPTION
* Fix typo in autocomplete's function name

[KP-667 in JIRA](https://kaholo.atlassian.net/browse/KP-677?atlOrigin=eyJpIjoiYzgyZWI3ZWU2YmQ4NDE1MDhlMzllZGQ4ZjQyMzcyNjkiLCJwIjoiaiJ9)